### PR TITLE
[italian] Improve inventory localization

### DIFF
--- a/community/inventory_service_tags_italian.txt
+++ b/community/inventory_service_tags_italian.txt
@@ -3,7 +3,7 @@ rarity		Rarità
 	uncommon		Non comune
 	rare		Raro
 	legendary		Leggendario
-	genuine		
-	strange		
+	genuine		Genuino
+	strange		Strano
 slot		
-	medal		
+	medal		Medaglia

--- a/community/item-schema.json
+++ b/community/item-schema.json
@@ -105,7 +105,7 @@
 			"briefing_name_brazilian": "Truque do Chapéu",
 			"briefing_name_english": "Trick Hat",
 			"briefing_name_german": "Trick Hut",
-			"briefing_name_italian": "Trucco col Cappello",
+			"briefing_name_italian": "Cappello Truccato",
 			"briefing_name_russian": "Шляпа с секретом",
 			"briefing_name_schinese": "帽子戏法",
 			"description_brazilian": "O truque é, que isso não é um chapéu ou uma medalha. É um adesivo comemorativo.",

--- a/community/item-schema.json
+++ b/community/item-schema.json
@@ -117,7 +117,7 @@
 			"after_description_brazilian": "Conquiste a proeza Pronto para Servir no Team Fortress 2 para desbloquear.",
 			"after_description_english": "Complete the Ready For Duty achievement in Team Fortress 2 to unlock.",
 			"after_description_german": "Schließe die Errungenschaft \"Ready For Duty\" in Team Fortress 2 ab, um sie freizuschalten.",
-			"after_description_italian": "Completa l'achievement Pronto al Dovere in Team Fortress 2 per sbloccarlo.",
+			"after_description_italian": "Completa l'achievement \"Pronto al Dovere\" in Team Fortress 2 per sbloccarlo.",
 			"after_description_russian": "Получите достижение «К бою готов» в Team Fortress 2, чтобы разблокировать её.",
 			"after_description_schinese": "在 Team Fortress 2 中完成 Ready For Duty 成就即可解锁。",
 			"display_type_brazilian": "Medalha…?",


### PR DESCRIPTION
This PR fixes the "Trick Hat" localization (which was translated as "Hat Trick"), adds missing quotes to its `after_description`, and translates some missing `inventory_service_tags`.