### PR TITLE
moved contribution and license information

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,6 @@ This repository contains all the files required to translate [Alien Swarm: React
 
 If you are not familiar with using GIT you can [download](https://github.com/ReactiveDrop/reactivedrop_translations/archive/refs/heads/master.zip) the repository as a ZIP archive and submit it using [Issues](https://github.com/ReactiveDrop/reactivedrop_translations/issues) tab, or edit the files in GitHub's web editor.
 
-### CONTRIBUTING
-
-Thanks for your interest in the Alien Swarm: Reactive Drop project. When you make a
-contribution to the project (e.g. create an Issue or submit a Pull Request)
-(a "Contribution"), Reactive Drop Team wants to be able to use your Contribution to improve
-the game.
-
-As a condition of providing a Contribution, you agree that:
-
-- You irrevocably grant anyone the right to use your work under the following license: Creative Commons CC0 Waiver (release all rights, like public domain: [legal code](https://creativecommons.org/publicdomain/zero/1.0/))
-- You warrant and represent that the Contribution is your original creation, that you have the authority to grant this license to anyone, and that this license does not require the permission of any third party. Otherwise, you provide your Contribution "as is" without warranties.
-
 ### How to translate?
 
 ### File Encoding


### PR DESCRIPTION
into separate files as proposed by github
reference: https://github.com/ReactiveDrop/reactivedrop_translations/community