### PR TITLE
(italian) Change "Speedrun Time" to "For Speedrun"

### DIFF
--- a/resource/reactivedrop_italian.txt
+++ b/resource/reactivedrop_italian.txt
@@ -3277,7 +3277,7 @@
 "[english]nb_difficulty_title"		"Difficulty"
 "nb_difficulty_title"		"Difficoltà"
 "[english]nb_speedruntime_title"		"Speedrun Time"
-"nb_speedruntime_title"		"Tempo Speedrun"
+"nb_speedruntime_title"		"Per Speedrun"
 // the first %d is minutes and the second %d is seconds (printf formatting). examples - 1:42, 3:10, 1:07
 "[english]nb_speedruntime_format"		"%d:%02d"
 "nb_speedruntime_format"		"%d:%02d"


### PR DESCRIPTION
The two letters of "Tempo Speedrun" get cut off in the mission briefing, so I attempted to change it to something shorter.