### PR TITLE
revert 2 schinese translation to default

### DIFF
--- a/resource/reactivedrop_schinese.txt
+++ b/resource/reactivedrop_schinese.txt
@@ -2080,7 +2080,7 @@
 "[english]asw_ammo_bag_exploded"		"%s1's ammo bag overheats and explodes!"
 "asw_ammo_bag_exploded"		"%s1 的弹药包因过热而爆炸了！"
 "[english]asw_team_killed"		"%s1 was killed by %s2."
-"asw_team_killed"		"%s1 被 %s2 杀死了，干得漂亮！"
+"asw_team_killed"		"%s1 被 %s2 杀死了。"
 "[english]asw_player_won_deathmatch"		"%s1 won the round. Congratulations!"
 "asw_player_won_deathmatch"		"%s1 赢了这一回合。祝贺！"
 "[english]asw_player_won_deathmatch_short"		"%s1 wins!"
@@ -4779,7 +4779,7 @@
 "[english]rd_ui_max_players"		"MAX PLAYERS"
 "rd_ui_max_players"		"最大玩家数"
 "[english]asw_chat_died"		"%s1 was killed in action!"
-"asw_chat_died"		"%s1 已阵亡，吐口痰再走！"
+"asw_chat_died"		"%s1 在行动中阵亡！"
 
 // Area9800 strings
 "[english]rd_area9800LZ_ob_destroy"		"Secure the hangar"


### PR DESCRIPTION
Current translation (before this commit) means:
[player%s is dead, spit on him before leaving!]
[player%s was killed by %s, nice job!]
Who the faak did this? I remember I changed them back several times.