### PR TITLE
(multiple) better points-reduced-message

### DIFF
--- a/resource/reactivedrop_brazilian.txt
+++ b/resource/reactivedrop_brazilian.txt
@@ -611,8 +611,8 @@
 "rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_czech.txt
+++ b/resource/reactivedrop_czech.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_danish.txt
+++ b/resource/reactivedrop_danish.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_dutch.txt
+++ b/resource/reactivedrop_dutch.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_english.txt
+++ b/resource/reactivedrop_english.txt
@@ -311,7 +311,7 @@
 "asw_objective_complete"	"Objective complete!"
 "rd_objective_chat_message"	"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 "rd_points_awarding_message"	"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-"rd_points_reduced_due_to_farming"	"You recently played this map. Gained points will be decreased.\n"
+"rd_points_reduced_due_to_farming"	"You recently played this map. Gained points have been decreased.\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "rd_hoiaf_new_personal_best_score_on_this_mission"	"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 // %s1 is a player name; %s2 and %s3 are numbers.

--- a/resource/reactivedrop_finnish.txt
+++ b/resource/reactivedrop_finnish.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_french.txt
+++ b/resource/reactivedrop_french.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_german.txt
+++ b/resource/reactivedrop_german.txt
@@ -611,7 +611,7 @@
 "rd_objective_chat_message"		"Ziel %s1 erfüllt! \nZeit: %s2 Delta zum vorherigen Ziel: %s3\n"
 "[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 "rd_points_awarding_message"		"%s4%s1 Punkte an %s4%s2 verliehen. Gesamt: %s4%s3\n"
-"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 "rd_points_reduced_due_to_farming"		"Du hast diesen Einsatz kürzlich gespielt. Gewonnene Punkte wurden verringert.\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_hungarian.txt
+++ b/resource/reactivedrop_hungarian.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_indonesian.txt
+++ b/resource/reactivedrop_indonesian.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_italian.txt
+++ b/resource/reactivedrop_italian.txt
@@ -611,8 +611,8 @@
 "rd_objective_chat_message"		"Obiettivo %s1 completato! \nTempo: %s2 Delta con obiettivo precedente: %s3\n"
 "[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 "rd_points_awarding_message"		"Assegnazione di %s4%s1 punti per %s4%s2, totale = %s4%s3\n"
-"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-"rd_points_reduced_due_to_farming"		"Hai giocato questa mappa di recente. Guadagnerai meno punti.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"Avete giocato questa mappa di recente. Si guadagnano meno punti.\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 "rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 ha battuto il suo miglior punteggio stagionale in questa missione (%s2) ottenendo un punteggio di %s3, così facendo ha aumentato i suoi punti bonus stagionali di +%s4!\n"

--- a/resource/reactivedrop_italian.txt
+++ b/resource/reactivedrop_italian.txt
@@ -612,7 +612,7 @@
 "[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 "rd_points_awarding_message"		"Assegnazione di %s4%s1 punti per %s4%s2, totale = %s4%s3\n"
 		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
-		"rd_points_reduced_due_to_farming"		"Avete giocato questa mappa di recente. Si guadagnano meno punti.\n"
+		"rd_points_reduced_due_to_farming"		"Hai giocato questa mappa di recente. I punti guadagnati sono stati ridotti.\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 "rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 ha battuto il suo miglior punteggio stagionale in questa missione (%s2) ottenendo un punteggio di %s3, così facendo ha aumentato i suoi punti bonus stagionali di +%s4!\n"

--- a/resource/reactivedrop_japanese.txt
+++ b/resource/reactivedrop_japanese.txt
@@ -611,8 +611,8 @@
 "rd_objective_chat_message"		"目標 %s1 達成！ \n時間: %s2 区間タイム: %s3\n"
 "[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 "rd_points_awarding_message"		"%s4%s2 が %s4%s1 ポイントを獲得、合計ポイント = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
-		"rd_points_reduced_due_to_farming"		"このマップは最近プレーされたばかりです。獲得ポイントは減少しています。\n"
+"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+"rd_points_reduced_due_to_farming"		"このマップは最近プレイしたばかりです。獲得ポイントが減少しました。\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 "rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1がこのミッションでの今シーズンのベストスコアを更新しました(%s2→%s3)。今シーズンのボーナスポイントが+%s4増加します！\n"

--- a/resource/reactivedrop_japanese.txt
+++ b/resource/reactivedrop_japanese.txt
@@ -611,8 +611,8 @@
 "rd_objective_chat_message"		"目標 %s1 達成！ \n時間: %s2 区間タイム: %s3\n"
 "[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 "rd_points_awarding_message"		"%s4%s2 が %s4%s1 ポイントを獲得、合計ポイント = %s4%s3\n"
-"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-"rd_points_reduced_due_to_farming"		"このマップは最近プレイしたばかりです。獲得できるポイントは減少します。\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"このマップは最近プレーされたばかりです。獲得ポイントは減少しています。\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 "rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1がこのミッションでの今シーズンのベストスコアを更新しました(%s2→%s3)。今シーズンのボーナスポイントが+%s4増加します！\n"

--- a/resource/reactivedrop_koreana.txt
+++ b/resource/reactivedrop_koreana.txt
@@ -612,7 +612,7 @@
 "[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 "rd_points_awarding_message"		"%s4%s2 해병이 %s4%s1 점 획득, 합계 점수 = %s4%s3\n"
 "[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
-"rd_points_reduced_due_to_farming"		"최근에 이 맵을 플레이했습니다. 획득한 점수가 감소했습니다.\n"
+"rd_points_reduced_due_to_farming"		"최근 이 맵을 플레이해서 획득 점수가 감소했습니다.\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 "rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 해병이 해당 임무의 시즌 최고 점수를 %s2 점에서 %s3 점으로 갱신하였습니다, 이번 시즌의 추가 점수가 +%s4 점 증가합니다!\n"

--- a/resource/reactivedrop_koreana.txt
+++ b/resource/reactivedrop_koreana.txt
@@ -611,8 +611,8 @@
 "rd_objective_chat_message"		" 목표 %s1  완료! \n시간: %s2  이전 목표로부터 소요된 시간: %s3\n"
 "[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 "rd_points_awarding_message"		"%s4%s2 해병이 %s4%s1 점 획득, 합계 점수 = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
-		"rd_points_reduced_due_to_farming"		"최근에 이 맵을 플레이했습니다. 획득한 점수가 감소했습니다.\n"
+"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+"rd_points_reduced_due_to_farming"		"최근에 이 맵을 플레이했습니다. 획득한 점수가 감소했습니다.\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 "rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 해병이 해당 임무의 시즌 최고 점수를 %s2 점에서 %s3 점으로 갱신하였습니다, 이번 시즌의 추가 점수가 +%s4 점 증가합니다!\n"

--- a/resource/reactivedrop_koreana.txt
+++ b/resource/reactivedrop_koreana.txt
@@ -611,8 +611,8 @@
 "rd_objective_chat_message"		" 목표 %s1  완료! \n시간: %s2  이전 목표로부터 소요된 시간: %s3\n"
 "[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 "rd_points_awarding_message"		"%s4%s2 해병이 %s4%s1 점 획득, 합계 점수 = %s4%s3\n"
-"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-"rd_points_reduced_due_to_farming"		"해당 맵을 플레이한지 얼마 되지 않아 획득 점수가 감소하였습니다.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"최근에 이 맵을 플레이했습니다. 획득한 점수가 감소했습니다.\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 "rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 해병이 해당 임무의 시즌 최고 점수를 %s2 점에서 %s3 점으로 갱신하였습니다, 이번 시즌의 추가 점수가 +%s4 점 증가합니다!\n"

--- a/resource/reactivedrop_latam.txt
+++ b/resource/reactivedrop_latam.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"¡Objetivo %s1 completado! \nTiempo: %s2 Diferencia con el objetivo anterior: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Otorgando %s4%s1 puntos a %s4%s2, en total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"Has jugado recientemente en este mapa. Los puntos obtenidos se reducirán.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"Has jugado recientemente en este mapa. Los puntos ganados se han reducido.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 mejoró su mejor puntaje personal de la temporada en esta misión de %s2 a %s3, ¡aumentando sus puntos de bonificación de esta temporada en +%s4!\n"

--- a/resource/reactivedrop_norwegian.txt
+++ b/resource/reactivedrop_norwegian.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_polish.txt
+++ b/resource/reactivedrop_polish.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_portuguese.txt
+++ b/resource/reactivedrop_portuguese.txt
@@ -611,8 +611,8 @@
 "rd_objective_chat_message"		"Objetivo \"%s1\" completado! \nTempo: %s2 Diferença com o objetivo anterior: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_romanian.txt
+++ b/resource/reactivedrop_romanian.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_russian.txt
+++ b/resource/reactivedrop_russian.txt
@@ -611,8 +611,8 @@
 "rd_objective_chat_message"		"Цель «%s1» выполнена! \nВремя: %s2 Перепад с предыдущей целью: %s3\n"
 "[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 "rd_points_awarding_message"		"Присуждается %s4%s1 очк. для %s4%s2, итого = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
-		"rd_points_reduced_due_to_farming"		"Вы недавно играли на этой карте. Полученные очки были уменьшены.\n"
+"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+"rd_points_reduced_due_to_farming"		"Вы недавно играли на этой карте. Полученные очки были уменьшены.\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 "rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 улучшает свой сезонный личный рекорд в этой миссии с %s2 до %s3, увеличив свои бонусные очки в этом сезоне на +%s4!\n"

--- a/resource/reactivedrop_russian.txt
+++ b/resource/reactivedrop_russian.txt
@@ -611,8 +611,8 @@
 "rd_objective_chat_message"		"Цель «%s1» выполнена! \nВремя: %s2 Перепад с предыдущей целью: %s3\n"
 "[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 "rd_points_awarding_message"		"Присуждается %s4%s1 очк. для %s4%s2, итого = %s4%s3\n"
-"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-"rd_points_reduced_due_to_farming"		"Вы недавно играли на этой карте. Полученные очки будут уменьшены.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"Вы недавно играли на этой карте. Полученные очки были уменьшены.\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 "rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 улучшает свой сезонный личный рекорд в этой миссии с %s2 до %s3, увеличив свои бонусные очки в этом сезоне на +%s4!\n"

--- a/resource/reactivedrop_schinese.txt
+++ b/resource/reactivedrop_schinese.txt
@@ -611,7 +611,7 @@
 "rd_objective_chat_message"		"完成了目标 %s1\n时间点：%s2 前一目标间隔：%s3\n"
 "[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 "rd_points_awarding_message"		"奖励 %s4%s1 点分数给 %s4%s2，总分数 = %s4%s3\n"
-"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 "rd_points_reduced_due_to_farming"		"由于近期玩过此地图，因此本次得分收益降低。\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_spanish.txt
+++ b/resource/reactivedrop_spanish.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_swedish.txt
+++ b/resource/reactivedrop_swedish.txt
@@ -611,8 +611,8 @@
 "rd_objective_chat_message"		"Mål %s1 slutfört! \nTid: %s2 Delta med tidigare mål: %s3\n"
 "[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 "rd_points_awarding_message"		"Belönar %s4%s1 poäng till %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
-		"rd_points_reduced_due_to_farming"		"Du spelade nyligen den här kartan. Intjänade poäng har minskats.\n"
+"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+"rd_points_reduced_due_to_farming"		"Du spelade nyligen den här kartan. Intjänade poäng har minskats.\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 "rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 har förbättrat sin säsongs bästa poäng på detta uppdrag från %s2 till %s3, som ökar dess bonus poäng med +%s4!\n"

--- a/resource/reactivedrop_swedish.txt
+++ b/resource/reactivedrop_swedish.txt
@@ -611,8 +611,8 @@
 "rd_objective_chat_message"		"Mål %s1 slutfört! \nTid: %s2 Delta med tidigare mål: %s3\n"
 "[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 "rd_points_awarding_message"		"Belönar %s4%s1 poäng till %s4%s2, total = %s4%s3\n"
-"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-"rd_points_reduced_due_to_farming"		"Du spelade nyligen den här kartan. Intjänade poäng kommer att minska.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"Du spelade nyligen den här kartan. Intjänade poäng har minskats.\n"
 // %s1 is a player name; %s2, %s3, and %s4 are numbers.
 "[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 "rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 har förbättrat sin säsongs bästa poäng på detta uppdrag från %s2 till %s3, som ökar dess bonus poäng med +%s4!\n"

--- a/resource/reactivedrop_tchinese.txt
+++ b/resource/reactivedrop_tchinese.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_thai.txt
+++ b/resource/reactivedrop_thai.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_turkish.txt
+++ b/resource/reactivedrop_turkish.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_ukrainian.txt
+++ b/resource/reactivedrop_ukrainian.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"

--- a/resource/reactivedrop_vietnamese.txt
+++ b/resource/reactivedrop_vietnamese.txt
@@ -611,8 +611,8 @@
 		"rd_objective_chat_message"		"Objective %s1 complete! \nTime: %s2 Delta with previous objective: %s3\n"
 		"[english]rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
 		"rd_points_awarding_message"		"Awarding %s4%s1 points to %s4%s2, total = %s4%s3\n"
-		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
-		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points will be decreased.\n"
+		"[english]rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
+		"rd_points_reduced_due_to_farming"		"You recently played this map. Gained points have been decreased.\n"
 		// %s1 is a player name; %s2, %s3, and %s4 are numbers.
 		"[english]rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"
 		"rd_hoiaf_new_personal_best_score_on_this_mission"		"%s1 has improved their seasonal personal best score on this mission from %s2 to %s3, increasing their bonus points this season by +%s4!\n"


### PR DESCRIPTION
I've refined a line (in the debriefing, after an successful mission) which tells the user that the currently earned points have been reduced.
Before, the message sounded like the next time you'll finish the mission your points will be reduced.

In these six languages i fumbled around with various translation engines: italian, japanese, koreana, latam, russian, swedish.
Since I can't speak them, I've also reindented the changed lines, so you can have another look at them.
👍 @MakinDay or @Steffo99
👍 @Deerlord0 
👍 @BRAIN-IS-BACK or @hangumi
@gaelcoral 
👍 @Blueberryy 
👍 @Crazymanbos 
please have a look at `rd_points_reduced_due_to_farming` in 037dedd320958003f3d9c61eaafd9a5d22468149 :)