### PR TITLE
Fix mission prep for Danish and Finnish

### DIFF
--- a/community/inventory_service/items_swedish.vdf
+++ b/community/inventory_service/items_swedish.vdf
@@ -276,7 +276,7 @@
 "[english]item_unique_medal_mapping_2023_description"		"This medal commemorates The Gauntlet: Arctic, the winner of the 2023 mapping competition."
 "item_unique_medal_mapping_2023_description"		"Denna medalj firar minnet av The Gauntlet: Arktis, vinnaren av karttävlingen 2023."
 "[english]item_unique_medal_mapping_2024_name"		"Downed Station (#SpaceStation2024 Winner)"
-"item_unique_medal_mapping_2024_name"		"Downed Station (#RymdStation2024 Vinnare)"
+"item_unique_medal_mapping_2024_name"		"Downed Station (#Rymdstation2024 Vinnare)"
 "[english]item_unique_medal_mapping_2024_description"		"This medal commemorates Downed Station, the winner of the 2024 mapping competition."
 "item_unique_medal_mapping_2024_description"		"Denna medalj firar minnet av Downed Station, vinnaren av karttävlingen 2024."
 

--- a/resource/reactivedrop_danish.txt
+++ b/resource/reactivedrop_danish.txt
@@ -3227,7 +3227,7 @@
 
 // new briefing
 "[english]nb_mission_prep"		"MISSION PREP"
-"nb_mission_prep"		"MISSIONSFORBEREDELSE"
+"nb_mission_prep"		"FORBEREDELSE"
 "[english]nb_ready"		"READY"
 "nb_ready"		"KLAR"
 "[english]nb_start_mission"		"START MISSION"

--- a/resource/reactivedrop_finnish.txt
+++ b/resource/reactivedrop_finnish.txt
@@ -3227,7 +3227,7 @@
 
 // new briefing
 "[english]nb_mission_prep"		"MISSION PREP"
-"nb_mission_prep"		"TEHTÄVÄÄN VALMISTAUTUMINEN"
+"nb_mission_prep"		"VALMISTAUTUMINEN"
 "[english]nb_ready"		"READY"
 "nb_ready"		"VALMIS"
 "[english]nb_start_mission"		"START MISSION"


### PR DESCRIPTION
I dont speak Danish, but it should be basically the same as Swedish. Just removing the word Mission and the rest means preparation.