### PR TITLE
Add file nesting for `.vdf`, `.txt`, `.json` and `.xml` files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
 	"explorer.fileNesting.patterns": {
 		"*_english.vdf": "${capture}_*.vdf",
 		"*_english.txt": "${capture}_*.txt",
-		"*_english.json": "${capture}_*.json"
+		"*_english.json": "${capture}_*.json",
+		"*_english.xml": "${capture}_*.xml"
 	}
 }


### PR DESCRIPTION
This PR adds to the Visual Studio Code workspace file nesting patterns (`explorer.fileNesting.patterns`) for `*_english.vdf` and `*_english.txt` files, making browsing the contents of the repository much easier.

Does not apply if file nesting is disabled (`explorer.fileNesting.enabled`), which is the default setting on Visual Studio Code.

# Video

https://github.com/user-attachments/assets/e3d667db-0692-4e1b-9f42-ada756304560

