### PR TITLE
Force "Valve Data Format" as repository main language in repository stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 *.txt text eol=crlf linguist-detectable linguist-language=vdf
 *.vdf text eol=crlf linguist-detectable linguist-language=vdf
 *.json text eol=lf linguist-detectable linguist-language=json
+*.xml linguist-detectable linguist-language=xml
 *.go text eol=lf
 go.* text eol=lf


### PR DESCRIPTION
This PR *should* change the displayed statistics for this repository to display "Valve Data File" as primary language.

The stats currently display:

<img width="324" height="103" alt="The language stats bar, displaying 93% Squirrel and 7% Go." src="https://github.com/user-attachments/assets/2c475d76-95bc-4396-9a8d-3964401231c3" />

Language name taken from the library GitHub uses to determine the statistics: https://github.com/github-linguist/linguist/blob/a7e40d31e271f6747fa1234df37b5fff3e6e2406/lib/linguist/languages.yml#L8116