### PR TITLE
Add Reversed Deima and Reversed Syntek to rich_presence

### DIFF
--- a/rich_presence/563560_loc_english.vdf
+++ b/rich_presence/563560_loc_english.vdf
@@ -121,7 +121,9 @@
 		"#official_mission_rd-bonus_mission6"	"High Tension + Crucial Point"
 		"#official_mission_rd-bonus_mission7"	"Power Plant"
 		"#official_mission_rd-bonus10_sewrev"	"Reversed Sewer Junction B5"
+		"#official_mission_rd-bonus11_synrev"	"Reversed SynTek Residential"
 		"#official_mission_rd-bonus12_rydrev"	"Reversed Rydberg Reactor"
+		"#official_mission_rd-bonus13_deimrev"	"Reversed Deima Surface Bridge"
 		"#official_mission_rd-bonus14_cargrev"	"Reversed Cargo Elevator"
 		"#official_mission_rd-bonus15_landrev"	"Reversed Landing Bay"
 	}

--- a/utils/achievements.go
+++ b/utils/achievements.go
@@ -332,7 +332,9 @@ var officialMissions = [...]string{
 	"rd-bonus_mission6",
 	"rd-bonus_mission7",
 	"rd-bonus10_sewrev",
+	"rd-bonus11_synrev",
 	"rd-bonus12_rydrev",
+	"rd-bonus13_deimrev",
 	"rd-bonus14_cargrev",
 	"rd-bonus15_landrev",
 }


### PR DESCRIPTION
Currently when player plays one of the newly added reversed maps the Steam rich presence shows no rich status at all.

Added map names to the 563560_loc_english.vdf and achievements.go.