### PR TITLE
Make Reversed SynTek Residential Escape objective translatable

### DIFF
--- a/resource/reactivedrop_brazilian.txt
+++ b/resource/reactivedrop_brazilian.txt
@@ -10837,5 +10837,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_czech.txt
+++ b/resource/reactivedrop_czech.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_danish.txt
+++ b/resource/reactivedrop_danish.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_dutch.txt
+++ b/resource/reactivedrop_dutch.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_english.txt
+++ b/resource/reactivedrop_english.txt
@@ -5792,5 +5792,7 @@
 "challenge_traitors_role_chat_role_description_mimic"		"Your quantum holographic cloak makes Alien Expert's scanner registers you as an IAF marine. Maintain disguise until critical moment."
 "challenge_traitors_role_chat_skill_description_mimic"		""
 "challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+"asw_ob_office_rev1"		"Escape using south door"
+"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_finnish.txt
+++ b/resource/reactivedrop_finnish.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_french.txt
+++ b/resource/reactivedrop_french.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_german.txt
+++ b/resource/reactivedrop_german.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 "[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 "challenge_traitors_role_hud_role_description_mimic"		"Der Scanner des Alien-Experten sieht dich als IAF-Soldat"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_hungarian.txt
+++ b/resource/reactivedrop_hungarian.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_indonesian.txt
+++ b/resource/reactivedrop_indonesian.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_italian.txt
+++ b/resource/reactivedrop_italian.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 "[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 "challenge_traitors_role_hud_role_description_mimic"		"Lo scanner dell'Esperto di Alieni ti vede come un soldato dell'IAF"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_japanese.txt
+++ b/resource/reactivedrop_japanese.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 "[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 "challenge_traitors_role_hud_role_description_mimic"		"エイリアン専門家のスキャナにIAF海兵隊員として写る"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_koreana.txt
+++ b/resource/reactivedrop_koreana.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 "[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 "challenge_traitors_role_hud_role_description_mimic"		"외계 전문가의 탐지기가 당신을 IAF 해병으로 인식합니다."
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_latam.txt
+++ b/resource/reactivedrop_latam.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_norwegian.txt
+++ b/resource/reactivedrop_norwegian.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_polish.txt
+++ b/resource/reactivedrop_polish.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_portuguese.txt
+++ b/resource/reactivedrop_portuguese.txt
@@ -10836,5 +10836,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_romanian.txt
+++ b/resource/reactivedrop_romanian.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_russian.txt
+++ b/resource/reactivedrop_russian.txt
@@ -10836,5 +10836,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 "[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 "challenge_traitors_role_hud_role_description_mimic"		"Сканер Экспертов По Жукам опознаёт вас как бойца МВС"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_schinese.txt
+++ b/resource/reactivedrop_schinese.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 "[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 "challenge_traitors_role_hud_role_description_mimic"		"你在异形专家那里显示为IAF队员"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_spanish.txt
+++ b/resource/reactivedrop_spanish.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_swedish.txt
+++ b/resource/reactivedrop_swedish.txt
@@ -10836,5 +10836,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 "[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 "challenge_traitors_role_hud_role_description_mimic"		"Alienexpertens skanner ser dig som en IAF-marinsoldat"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_tchinese.txt
+++ b/resource/reactivedrop_tchinese.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 "[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 "challenge_traitors_role_hud_role_description_mimic"		"異形專家的掃描器認為你是IAF成員。"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_thai.txt
+++ b/resource/reactivedrop_thai.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_turkish.txt
+++ b/resource/reactivedrop_turkish.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_ukrainian.txt
+++ b/resource/reactivedrop_ukrainian.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }

--- a/resource/reactivedrop_vietnamese.txt
+++ b/resource/reactivedrop_vietnamese.txt
@@ -10835,5 +10835,9 @@
 "challenge_traitors_role_chat_skill_description_mimic"		""
 		"[english]challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
 		"challenge_traitors_role_hud_role_description_mimic"		"Alien Expert's scanner sees you as an IAF marine"
+		"[english]asw_ob_office_rev1"		"Escape using south door"
+		"asw_ob_office_rev1"		"Escape using south door"
+		"[english]asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
+		"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"
 }
 }


### PR DESCRIPTION
Added two new strings
"asw_ob_office_rev1"		"Escape using south door"
"asw_ob_office_rev1b"		"Proceed to the Rydberg Reactor"